### PR TITLE
Update README.md with bastion host requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Has in-built support for bastion hosts (also known as jump hosts).
 * [Usage](#usage)
 * [API](#api)
 
+
+
+
 ## <a name="installation">Installation</a>
 
 ```sh
@@ -22,6 +25,8 @@ $ yarn add node-ssh-forward
 ## <a name="usage">Usage</a>
 
 Setting up the initial ssh connection (using a bastion host)
+
+Bastion host **needs** access to `nc`([netcat](https://ru.wikipedia.org/wiki/Netcat)) command, for example newer aws instances [Linux 2](https://aws.amazon.com/ru/amazon-linux-2/) doesn't have it in base package
 
 ```js
 import { SSHConnection } from ‘node-ssh-forward’

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ yarn add node-ssh-forward
 
 Setting up the initial ssh connection (using a bastion host)
 
-Bastion host **needs** access to `nc`([netcat](https://ru.wikipedia.org/wiki/Netcat)) command, for example newer aws instances [Linux 2](https://aws.amazon.com/ru/amazon-linux-2/) doesn't have it in base package
+Bastion host **needs** access to `nc`([netcat](https://en.wikipedia.org/wiki/Netcat)) command, for example the AMIs of newer AWS [Linux 2](https://aws.amazon.com/ru/amazon-linux-2/) instances don't have it installed in their base package
 
 ```js
 import { SSHConnection } from ‘node-ssh-forward’


### PR DESCRIPTION
I hit this and without reading the source code and previous knowledge of missing packages it would be hard to understand why `forward` would just stuck on second hop, from bastion.