### PR TITLE
Added option which will try "keyboard-interactive" user authentication 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Options are an object with following properties:
 * `bastionHost` (optional): You can specify a bastion host if you want
 * `passphrase` (optional): You can specify the passphrase when you have an encrypted private key. If you don't specify the passphrase and you use an encrypted private key, you get prompted in the command line.
 * `noReadline` (optional): Don't prompt for private key passphrases using readline (eg if this is not run in an interactive session)
+* `tryKeyboardInteractive` (optional): Try keyboard-interactive user authentication if primary authentication method fails, and prompts provided by SSH server (defaults to `false`)
+
 
 #### `connection.executeCommand(command: string): Promise<void>`
 


### PR DESCRIPTION
Added ability to handle "keyboard-interactive" user authentication if primary authentication fails. 

My use case for this feature is discussed in #31 . This works perfectly with user authentication when SSH server setup to use public key and multi-factor authentication. To try this out you can setup an SSH host on AWS as discussed in this article: https://www.middlewareinventory.com/blog/aws-mfa-ssh-ec2-setup/ and ssh to it. 

Options for such a setup would be as simple as:

```
export const sshConfig:Options = {
    endHost: '<ssh_host>,
    username: '<ssh_user>',
    privateKey: fs.readFileSync('<private_key>'),
    tryKeyboardInteractive:true
}
```

If "keyboard-interactive" authentication is initiated by the server, prompts passed in by the server will be shown, and the library will wait for keyboard input from the user before proceeding.

Note that if is set to true but "keyboard-interactive" authentication is not initiated by the server, the option will do nothing. 

The README.md file has been updated to include a description of the new `tryKeyboardInteractive` option (which was lifted from the `ssh2` library's own documentation).
