### PR TITLE
basic host key verification idea

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Options are an object with following properties:
 * `bastionHost` (optional): You can specify a bastion host if you want
 * `passphrase` (optional): You can specify the passphrase when you have an encrypted private key. If you don't specify the passphrase and you use an encrypted private key, you get prompted in the command line.
 * `noReadline` (optional): Don't prompt for private key passphrases using readline (eg if this is not run in an interactive session)
+* `verifyKnownHosts` (optional): Verify remote SSH hostkey using your known_hosts. The implementation only works on systems with an OpenSSH (OpenBSD) version of ssh-keygen.
 
 #### `connection.executeCommand(command: string): Promise<void>`
 


### PR DESCRIPTION
Addresses #41 

This adds a trivial but working verification for clients with `ssh-keygen -F` (so not Windows -> opt-in Flag). 
Making something that more generally covers more systems is likely much harder.

- [ ] Maybe if this is too much logic, there could also be an alternative option for the user to specify/pass their own custom hostVerifier function / so they could hardcode their list of keys in there.