### PR TITLE
Allow connections from anothers hosts

### DIFF
--- a/src/Connection.ts
+++ b/src/Connection.ts
@@ -38,6 +38,7 @@ interface Options {
 }
 
 interface ForwardingOptions {
+  fromHost?: string
   fromPort: number
   toPort: number
   toHost?: string
@@ -219,14 +220,14 @@ class SSHConnection {
     return new Promise((resolve, reject) => {
       this.server = net.createServer((socket) => {
         this.debug('Forwarding connection from "localhost:%d" to "%s:%d"', options.fromPort, options.toHost, options.toPort)
-        connection.forwardOut('localhost', options.fromPort, options.toHost || 'localhost', options.toPort, (error, stream) => {
+        connection.forwardOut(options.fromHost || 'localhost', options.fromPort, options.toHost || 'localhost', options.toPort, (error, stream) => {
           if (error) {
             return reject(error)
           }
           socket.pipe(stream)
           stream.pipe(socket)
         })
-      }).listen(options.fromPort, 'localhost', () => {
+      }).listen(options.fromPort, options.fromHost || 'localhost', () => {
         return resolve()
       })
     })


### PR DESCRIPTION
Added 'fromHost' in `ForwardingOptions`  to allow connections from another's hosts.

// example

```typescript
await sshConnection.forward({
    fromHost: '0.0.0.0',
    fromPort: 5980,
    toPort: 554,
    toHost: '10.0.0.141',
  });
console.log('*:5980 -> 10.0.0.141:554');
```